### PR TITLE
GitHub Actions STEP_SUMMARY 機能を追加してワークフロー実行結果の可視性を向上

### DIFF
--- a/.github/workflows/reusable-review-dependency-pr.yml
+++ b/.github/workflows/reusable-review-dependency-pr.yml
@@ -148,4 +148,4 @@ jobs:
           AI_REVIEW: ${{ steps.ai-review.outputs.response }}
         run: |
           cd review-tool
-          deno run --allow-net --allow-env src/post-review.ts
+          deno run --allow-net --allow-env --allow-write src/post-review.ts

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -3,19 +3,23 @@
 ## コメント管理機能
 
 ### AIレビューコメントの更新機能
+
 - 同一PRに対する複数回のAIレビュー実行時、新しいコメントを作成するのではなく、既存のAIコメントを更新する
 - AIコメントの識別は `<!-- AI-REVIEW-COMMENT -->` 識別子を使用
 - 既存AIコメントが存在しない場合は新規作成、存在する場合は更新を行う
 
 ### GitHubApiService インターフェース
+
 - `getIssueComments(prNumber: number)`: PRの既存コメント一覧を取得
 - `updateComment(commentId: number, body: string)`: 指定コメントIDのコメントを更新
 - `createOrUpdateReviewComment(prNumber: number, body: string)`: AIレビューコメントの作成・更新を自動判定
 
 ### コメント識別子
+
 - AIが生成したコメントには `<!-- AI-REVIEW-COMMENT -->` をHTMLコメントとして埋め込み
 - この識別子により、既存のAIコメントを特定・更新可能
 
 ## 後方互換性
+
 - 既存の `createComment()` メソッドは保持され、従来通り動作
 - `post-review.ts` では新しい `createOrUpdateReviewComment()` を使用


### PR DESCRIPTION
## 概要
GitHub Actions の STEP_SUMMARY 機能を実装し、ワークフロー実行結果で対象PRとコメント情報を確認できるようにしました。

## 変更内容
- `GitHubApiService` の `createOrUpdateReviewComment` メソッドがコメント情報（ID、URL、操作種別）を返すように修正
- `post-review.ts` で STEP_SUMMARY ファイルに結果を出力する `writeStepSummary` 関数を追加
- ワークフローからの実行時に対象PR、コメントURL、レビュー内容の要約が表示されるように改善
- テストケースを更新し、新しい戻り値の型に対応
- Deno の `--allow-write` 権限を追加

## 表示される情報
- 対象PR番号とURL
- PRタイトルと作成者
- コメントのURL
- レビュー内容の要約（200文字）
- 作成/更新の操作種別

## テスト結果
- 全てのテストが正常に通過
- 型チェックも問題なし

🤖 Generated with [Claude Code](https://claude.ai/code)